### PR TITLE
Implement XenServer rolling reboot scripts

### DIFF
--- a/cloudstackops/cloudstackops.py
+++ b/cloudstackops/cloudstackops.py
@@ -1361,9 +1361,11 @@ class CloudStackOps(CloudStackOpsBase):
                          "Managed state",
                          "Hypervisortype",
                          "XenServer HA",
+                         "Patch level",
                          "Pod name",
                          "Zone name"])
         t.align["Cluster name"] = "l"
+        t.max_width["Patch level"] = 44
 
         try:
             clusterHostsData = self.getAllHostsFromCluster(clusterID)
@@ -1372,12 +1374,22 @@ class CloudStackOps(CloudStackOpsBase):
         except:
             xenserver_ha_state = "N/A"
 
+        try:
+            if not clusterHostsData:
+                clusterHostsData = self.getAllHostsFromCluster(clusterID)
+            xenserver_patch_level = self.xenserver.get_patch_level(
+                clusterHostsData[0])
+        except:
+            xenserver_patch_level = "N/A"
+
+
         for cluster in clusterData:
             t.add_row([cluster.name,
                        cluster.allocationstate,
                        cluster.managedstate,
                        cluster.hypervisortype,
                        xenserver_ha_state,
+                       xenserver_patch_level,
                        cluster.podname,
                        cluster.zonename])
         # Print table

--- a/cloudstackops/cloudstackops.py
+++ b/cloudstackops/cloudstackops.py
@@ -1359,13 +1359,12 @@ class CloudStackOps(CloudStackOpsBase):
         t = PrettyTable(["Cluster name",
                          "Allocation state",
                          "Managed state",
-                         "Hypervisortype",
                          "XenServer HA",
                          "Patch level",
                          "Pod name",
                          "Zone name"])
         t.align["Cluster name"] = "l"
-        t.max_width["Patch level"] = 44
+        t.max_width["Patch level"] = 32
 
         try:
             clusterHostsData = self.getAllHostsFromCluster(clusterID)
@@ -1387,7 +1386,6 @@ class CloudStackOps(CloudStackOpsBase):
             t.add_row([cluster.name,
                        cluster.allocationstate,
                        cluster.managedstate,
-                       cluster.hypervisortype,
                        xenserver_ha_state,
                        xenserver_patch_level,
                        cluster.podname,

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -64,7 +64,9 @@ class xenserver():
     def get_patch_level(self, host):
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
-                return fab.run(" xe patch-list | grep XS | awk {'print $4'} | sort | tr '\n' ' '")
+                return fab.run("for p in $(xe patch-list | grep XS | awk {'print $4'} | tr -d \" \" |\
+                sort | tr '\n' ' '); do echo -n $p \"(\"; xe patch-list name-label=$p params=hosts |\
+                awk -F: {'print $2'} | tr -cd , | awk {'print $1 \",\"'} | tr -d '\n' | wc -c | tr -d '\n'; echo -n \") \"; done")
         except:
             return False
 

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -1,0 +1,227 @@
+#!/usr/bin/python
+
+#      Copyright 2015, Schuberg Philis BV
+#
+#      Licensed to the Apache Software Foundation (ASF) under one
+#      or more contributor license agreements.  See the NOTICE file
+#      distributed with this work for additional information
+#      regarding copyright ownership.  The ASF licenses this file
+#      to you under the Apache License, Version 2.0 (the
+#      "License"); you may not use this file except in compliance
+#      with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#      Unless required by applicable law or agreed to in writing,
+#      software distributed under the License is distributed on an
+#      "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#      KIND, either express or implied.  See the License for the
+#      specific language governing permissions and limitations
+#      under the License.
+
+# We depend on these
+import socket
+import sys
+import time
+
+# Fabric
+from fabric.api import *
+from fabric import api as fab
+from fabric import *
+
+
+# Class to handle XenServer patching
+class xenserver():
+
+    def __init__(self, ssh_user='root'):
+        self.ssh_user = ssh_user
+
+    # Wait for hypervisor to become alive again
+    def check_connect(self, host):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        print "Note: Waiting for " + host.name + "(" + host.ipaddress + ") to return"
+        while s.connect_ex((host.ipaddress, 22)) > 0:
+            # Progress indication
+            sys.stdout.write(".")
+            sys.stdout.flush()
+            time.sleep(5)
+        # Remove progress indication
+        sys.stdout.write("\033[F")
+        print "Note: Host " + host.name + " is alive again!"
+        print "Note: Waiting a bit before moving on to allow everything to start fully.."
+        time.sleep(30)
+        return True
+
+    # Return host of poolmaster
+    def get_poolmaster(self, host):
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("xe host-list uuid=$(xe pool-list params=master | awk {'print $5'}) params=name-label | awk {'print $5'} | tr -d '\n'")
+        except:
+            return False
+
+    def check_patch(self):
+        pass
+
+    def host_check_reboot_needed(self):
+        pass
+
+    # Put a host to service in XenServer
+    def host_enable(self, host):
+        print "Note: Enabling host " + host.name
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("xe host-enable host=" + host.name)
+        except:
+            return False
+
+    # Put a host to maintenance in XenServer
+    def host_disable(self, host):
+        print "Note: Disabling host " + host.name
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("xe host-disable host=" + host.name)
+        except:
+            print "Warning: host_disable returned false for " + host.name
+            return False
+
+    # Live migrate all VMS off of a hypervisor
+    def host_evacuate(self, host):
+        print "Note: Evacuating host " + host.name
+        print "Note: Migration progress will appear here.."
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                fab.run("nohup xe host-evacuate host=" + host.name +
+                        " >& /dev/null < /dev/null &", pty=False)
+
+            while True:
+                numer_of_vms = self.host_get_vms(host)
+                # Overwrite previous lin_
+                sys.stdout.write("\033[F")
+                print "Progress: On host " + host.name + " there are " + numer_of_vms + " VMs left to be migrated.."
+                if int(numer_of_vms) == 0:
+                    break
+                time.sleep(5)
+            return True
+        except:
+            return False
+
+    # Reboot a host when all conditions are met
+    def host_reboot(self, host):
+        # Disbale host
+        if self.host_disable(host) is False:
+            print "Error: Disabling host " + host.name + " failed."
+            return False
+
+        # Then evacuate it
+        if self.host_evacuate(host) is False:
+            print "Error: Evacuating host " + host.name + " failed."
+            return False
+
+        # Count VMs to be sure
+        if self.host_get_vms(host) != "0":
+            print "Error: Host " + host.name + " not empty, cannot reboot!"
+            return False
+        print "Note: Host " + host.name + " has no VMs running, continuing"
+
+        # Finally reboot it
+        print "Note: Rebooting host " + host.name
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                fab.run("xe host-reboot host=" + host.name)
+        except:
+            print "Error: Rebooting host " + host.name + " failed."
+            return False
+
+        # Wait for the host to shutdown
+        print "Note: Waiting 30s to allow the host to shutdown."
+        time.sleep(30)
+
+        # Wait until the host is back
+        self.check_connect(host)
+
+        # Enable host
+        if self.host_enable(host) is False:
+            print "Error: Enabling host " + host.name + " failed."
+            return False
+
+    # Get VM count of a hypervisor
+    def host_get_vms(self, host):
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("xl list-vm | grep -v UUID | wc -l")
+        except:
+            return False
+
+    # Enable XenServer poolHA
+    def pool_ha_enable(self, host):
+        print "Note: Enabling HA"
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("xe pool-ha-enable heartbeat-sr-uuids=$(xe sr-list type=nfs params=uuid --minimal) ha-config:timeout=180")
+        except:
+            return False
+
+    # Disable XenServer poolHA
+    def pool_ha_disable(self, host):
+        print "Note: Disabling HA"
+        if self.pool_ha_check(host):
+            try:
+                with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                    return fab.run("xe pool-ha-disable")
+            except:
+                return False
+        else:
+            return "Error"
+
+    # Check the current state of HA
+    def pool_ha_check(self, host):
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                if fab.run("xe pool-list params=ha-enabled | awk {'print $5'} | tr -d '\n'") == "true":
+                    return True
+                else:
+                    return False
+        except:
+            return "Error"
+
+    # Make sure hosts are put to Enabled again
+    def roll_back(self, host):
+        print "Note: Problem detected, rolling back."
+
+        # Enable host
+        if self.host_enable(host) is False:
+            print "Error: Enabling host " + host.name + " failed."
+            return False
+
+    # Upload check scripts
+    def put_scripts(self, host):
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                put('xenserver_check_bonds.py',
+                    '/tmp/xenserver_check_bonds.py', mode=0755)
+                put('xenserver_fake_pvtools.sh',
+                    '/tmp/xenserver_fake_pvtools.sh', mode=0755)
+            return True
+        except:
+            print "Warning: Could not upload check scripts to host " + host.name + ". Continuing anyway."
+            return False
+
+    # Fake PV tools
+    def fake_pv_tools(self, host):
+        print "Note: We're faking the presence of PV tools of all vm's reporting no tools on hypervisor '" + host.name
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("xe vm-list PV-drivers-up-to-date='<not in database>' is-control-domain=false\
+                    resident-on=$(xe host-list name-label=$HOSTNAME --minimal) params=uuid --minimal\
+                    |tr ', ' '\n'| grep \"-\" | awk {'print \"/tmp/xenserver_fake_pvtools.sh \" $1'} | sh")
+        except:
+            return False
+
+    # Get bond status
+    def get_bond_status(self, host):
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("python /tmp/xenserver_check_bonds.py | awk {'print $1'} | tr -d \":\"")
+        except:
+            return False

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -47,7 +47,7 @@ class xenserver():
             time.sleep(5)
         # Remove progress indication
         sys.stdout.write("\033[F")
-        print "Note: Host " + host.name + " is alive again!"
+        print "Note: Host " + host.name + " is alive again!                             "
         print "Note: Waiting a bit before moving on to allow everything to start fully.."
         time.sleep(30)
         return True

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -60,6 +60,14 @@ class xenserver():
         except:
             return False
 
+    # Get current patchlevel
+    def get_patch_level(self, host):
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run(" xe patch-list | grep XS | awk {'print $4'} | sort | tr '\n' ' '")
+        except:
+            return False
+
     def check_patch(self):
         pass
 

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -50,7 +50,7 @@ class xenserver():
         sys.stdout.write("\033[F")
         print "Note: Host " + host.name + " responds to SSH again!                           "
         print "Note: Waiting until we can successfully run a XE command against the cluster.."
-        while self.check_xapi(host) > 0:
+        while self.check_xapi(host) is False:
             # Progress indication
             sys.stdout.write(".")
             sys.stdout.flush()
@@ -64,9 +64,9 @@ class xenserver():
     def check_xapi(self, host):
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
-                with settings(warn_only=True):
-                    result_code = fab.run("xe host-enable host=host.name")
-                if result_code == 0:
+                with warn_only():
+                    result = fab.run("xe host-enable host=" + host.name)
+                if result.return_code == 0:
                     return True
                 else:
                     return False

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -74,7 +74,6 @@ class xenserver():
 
     # Check if we are really offline
     def check_offline(self, host):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         print "Note: Waiting for " + host.name + " to go offline"
         while os.system("ping -c 1 " + host.ipaddress + " 2>&1 >/dev/null") == 0:
             # Progress indication

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -64,7 +64,8 @@ class xenserver():
     def check_xapi(self, host):
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
-                result_code = fab.run("xe host-enable host=host.name")
+                with settings(warn_only=True):
+                    result_code = fab.run("xe host-enable host=host.name")
                 if result_code == 0:
                     return True
                 else:

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -200,7 +200,7 @@ class xenserver():
         print "Note: Enabling HA"
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
-                return fab.run("xe pool-ha-enable heartbeat-sr-uuids=$(xe sr-list type=nfs params=uuid --minimal) ha-config:timeout=180")
+                return fab.run("xe pool-ha-enable heartbeat-sr-uuids=$(xe sr-list type=nfs params=uuid --minimal) ha-config:timeout=180 ha-config:ha-host-failures-to-tolerate=1")
         except:
             return False
 

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -131,7 +131,7 @@ class xenserver():
 
     # Live migrate all VMS off of a hypervisor
     def host_evacuate(self, host):
-        print "Note: Evacuating host " + host.name
+        print "Note: Evacuating host " + host.name + " @ " + time.strftime("%Y-%m-%d %H:%M")
         print "Note: Migration progress will appear here.."
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
@@ -145,6 +145,7 @@ class xenserver():
                 if int(numer_of_vms) == 0:
                     break
                 time.sleep(5)
+            print "Note: Done evacuating host " + host.name + " @ " + time.strftime("%Y-%m-%d %H:%M")
             return True
         except:
             return False

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -217,9 +217,19 @@ class xenserver():
             print "Warning: Could not upload check scripts to host " + host.name + ". Continuing anyway."
             return False
 
+    # Eject CDs
+    def eject_cds(self, host):
+        print "Note: We're ejecting all mounted CDs on this cluster."
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("for vm in $(xe vbd-list type=CD empty=false params=vm-uuid --minimal |\
+                    tr \",\" \" \"); do echo \"xe vm-cd-eject uuid=\"$vm; done | sh")
+        except:
+            return False
+
     # Fake PV tools
     def fake_pv_tools(self, host):
-        print "Note: We're faking the presence of PV tools of all vm's reporting no tools on hypervisor '" + host.name
+        print "Note: We're faking the presence of PV tools of all vm's reporting no tools on hypervisor " + host.name
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
                 return fab.run("xe vm-list PV-drivers-up-to-date='<not in database>' is-control-domain=false\

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -64,7 +64,7 @@ class xenserver():
     def check_xapi(self, host):
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
-                result_code = fab.run("xe host-list")
+                result_code = fab.run("xe host-enable host=host.name")
                 if result_code == 0:
                     return True
                 else:

--- a/xenserver_check_bonds.py
+++ b/xenserver_check_bonds.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+
+#      Copyright 2015, Schuberg Philis BV
+#
+#      Licensed to the Apache Software Foundation (ASF) under one
+#      or more contributor license agreements.  See the NOTICE file
+#      distributed with this work for additional information
+#      regarding copyright ownership.  The ASF licenses this file
+#      to you under the Apache License, Version 2.0 (the
+#      "License"); you may not use this file except in compliance
+#      with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#      Unless required by applicable law or agreed to in writing,
+#      software distributed under the License is distributed on an
+#      "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#      KIND, either express or implied.  See the License for the
+#      specific language governing permissions and limitations
+#      under the License.
+
+
+import sys
+import socket
+import time
+import re
+import os
+import XenAPI
+
+# check xen bond status
+
+DEBUG = False
+
+
+def log(s):
+    if DEBUG:
+        print s
+
+
+def get_bonds(session, host):
+    bonds = {}
+    slaves = {}
+
+    for (b, brec) in session.xenapi.PIF.get_all_records().items():
+        # only local interfaces
+        if brec['host'] != host:
+            continue
+        # save masters and slaves
+        if brec['bond_master_of']:
+            bonds[b] = brec
+        if brec['bond_slave_of']:
+            slaves[b] = brec
+
+    for (m, mrec) in session.xenapi.PIF_metrics.get_all_records().items():
+        for srec in slaves.values():
+            if srec['metrics'] != m:
+                continue
+            srec['carrier'] = mrec['carrier']
+
+    for (n, nrec) in session.xenapi.network.get_all_records().items():
+        for brec in bonds.values():
+            if brec['network'] != n:
+                continue
+            brec['name_label'] = nrec['name_label']
+
+    return bonds, slaves
+
+
+def get_bond_status(session, host):
+    status = {}
+    for (b, brec) in session.xenapi.Bond.get_all_records().items():
+        status[b] = brec
+
+    return status
+
+
+def main():
+
+    # First acquire a valid session by logging in:
+    session = XenAPI.xapi_local()
+    session.xenapi.login_with_password("root", "")
+
+    hostname = socket.gethostname()
+    host = (session.xenapi.host.get_by_name_label(hostname))[0]
+
+    # warning when host not found...
+    if not host:
+        print "failed to detect XAPI host for '%s'" % hostname
+        sys.exit(1)
+
+    bonds, slaves = get_bonds(session, host)
+    bond_status = get_bond_status(session, host)
+
+    clist = []
+    olist = []
+
+    # iterate over the bonds
+    for b in bonds:
+        net = bonds[b]['name_label']
+        ref = bonds[b]['bond_master_of'][0]
+        status = bond_status[ref]
+
+        # On XenServer 6.0 we manually build links_up by checking carrier
+        if 'links_up' not in status:
+
+            status['links_up'] = 0
+
+            for slave in status['slaves']:
+                if slaves[slave]['carrier']:
+                    status['links_up'] += 1
+
+        if len(status['slaves']) != int(status['links_up']):
+            clist.append("%s has only %s links up (%s slaves)"
+                         % (net, status['links_up'], len(status['slaves'])))
+        else:
+            olist.append("%s %s links up" % (net, status['links_up']))
+
+    if len(clist):
+        print "CRITICAL:", ", ".join(clist)
+        return 2
+    elif len(olist):
+        print "OK:", ", ".join(olist)
+        return 0
+    else:
+        print "OK: no bonds found"
+        return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xenserver_fake_pvtools.sh
+++ b/xenserver_fake_pvtools.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+usage() {
+  echo "$0 <VM uuid>"
+  echo " -- fakes the presence of PV tools in <VM uuid>"
+  echo " -- NB the VM must be either paused or running on localhost"
+}
+
+fake(){
+  local uuid=$1
+  domid=$(xe vm-list uuid=${uuid} params=dom-id --minimal)
+  xenstore-write /local/domain/${domid}/attr/PVAddons/MajorVersion ${major} \
+                 /local/domain/${domid}/attr/PVAddons/MinorVersion ${minor} \
+                 /local/domain/${domid}/attr/PVAddons/MicroVersion ${micro} \
+                 /local/domain/${domid}/data/updated 1
+}
+
+uuid=$(xe vm-list uuid=$1 params=uuid --minimal)
+if [ $? -ne 0 ]; then
+  echo "Argument should be a VM uuid"
+  usage
+  exit 1
+fi
+
+# use the PRODUCT_VERSION from here:
+. /etc/xensource-inventory
+
+major=$(echo ${PRODUCT_VERSION} | cut -f 1 -d .)
+minor=$(echo ${PRODUCT_VERSION} | cut -f 2 -d .)
+micro=$(echo ${PRODUCT_VERSION} | cut -f 3 -d .)
+
+# Check the VM is running on this host
+resident_on=$(xe vm-list uuid=${uuid} params=resident-on --minimal)
+if [ "${resident_on}" != "${INSTALLATION_UUID}" ]; then
+  echo "VM must be resident on this host"
+  exit 2
+fi
+
+power_state=$(xe vm-list uuid=${uuid} params=power-state --minimal)
+case "${power_state}" in
+  running)
+    fake $uuid
+    ;;
+  paused)
+    fake $uuid
+    ;;
+  *)
+    echo "VM must be either running or paused"
+    exit 3
+    ;;
+esac

--- a/xenserver_parallel_evacuate.py
+++ b/xenserver_parallel_evacuate.py
@@ -1,0 +1,234 @@
+#!/usr/bin/python
+
+#      Copyright 2015, Schuberg Philis BV
+#
+#      Licensed to the Apache Software Foundation (ASF) under one
+#      or more contributor license agreements.  See the NOTICE file
+#      distributed with this work for additional information
+#      regarding copyright ownership.  The ASF licenses this file
+#      to you under the Apache License, Version 2.0 (the
+#      "License"); you may not use this file except in compliance
+#      with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#      Unless required by applicable law or agreed to in writing,
+#      software distributed under the License is distributed on an
+#      "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#      KIND, either express or implied.  See the License for the
+#      specific language governing permissions and limitations
+#      under the License.
+
+# Evacuate a XenServer using multiple threads in parallel
+# Remi Bergsma, rbergsma@schubergphilis.com
+
+# We depend on these modules
+import sys
+import socket
+import time
+import os
+import getopt
+import subprocess
+
+
+# Argument handling Class
+class handleArguments(object):
+    def handleArguments(self,argv):
+        self.DEBUG = 0
+        self.DRYRUN = 1
+        self.threads = 5
+
+        # Usage message
+        help = "Usage: " + os.path.basename(__file__) + ' --threads [--debug --exec ]'
+
+        try:
+            opts, args = getopt.getopt(argv,"ht:",["threads=","debug","exec"])
+        except getopt.GetoptError:
+            print help
+            sys.exit(2)
+        for opt, arg in opts:
+            if opt == '-h':
+                print help
+                sys.exit()
+            elif opt in ("-t","--threads"):
+                self.threads = arg
+            elif opt in ("--debug"):
+                self.DEBUG = 1
+            elif opt in ("--exec"):
+                self.DRYRUN = 0
+
+# Class to handle XenServer parallel evactation
+class xenserver_parallel_evacuation(object):
+
+    def __init__(self, arg):
+        self.DEBUG = arg.DEBUG
+        self.DRYRUN = arg.DRYRUN
+        self.threads = arg.threads
+        self.poolmember = False
+        self.vmlist = False
+        self.hvlist = False
+
+    # Run local command
+    def run_local_command(self, command):
+        if self.DEBUG == 1:
+            print "Debug: Running command:" + command
+
+        # XenServer 6.2 runs an ancient python 2.4
+        # and the subprocess module did not work
+        # properly. That's why I used ancient os.*
+        p = os.popen(command)
+        lines = ""
+        while 1:
+            line = p.readline()
+            if not line: break
+            lines += line
+
+        return lines
+
+    # Get overview of free memory on enabled hosts
+    def get_hypervisor_free_memory(self):
+            return self.run_local_command("for h in $(xe host-list params=name-label \
+                                           enabled=true --minimal | tr ',' ' '); \
+                                           do echo -n \"$h,\"; \
+                                           xe host-compute-free-memory host=$h;done")
+
+    # Get overview of VMs and their memory
+    def get_vms_with_memory_from_hypervisor(self):
+        try:
+            return self.run_local_command("xe vm-list resident-on=$(xe host-list params=uuid \
+                                           name-label=$HOSTNAME --minimal) \
+                                           params=name-label,memory-static-max is-control-domain=false |\
+                                           tr '\\n' ' ' | sed 's/name-label/\\n/g' | \
+                                           awk {'print $4 \",\" $8'} | sed '/^,$/d'")
+        except:
+            return False
+
+    # Get overview of peer hypervisors and their available memory
+    def construct_poolmembers(self):
+        self.hvlist = self.get_hypervisor_free_memory()
+
+        # Construct poolmembers
+        poolmember = {}
+        hvlist_iter = self.hvlist.split('\n')
+        for hv in hvlist_iter:
+            info = hv.split(',')
+            try:
+                hv = info[0]
+                mem = info[1]
+            except:
+                continue
+            poolmember[hv] = {}
+            poolmember[hv]['memory_free'] = int(mem)
+            poolmember[hv]['name'] = hv
+        return poolmember
+
+    # Get the hypervisor with the most free memory
+    def get_hypervisor_with_most_free_memory(self):
+        if self.poolmember == False:
+            self.poolmember = self.construct_poolmembers()
+        return sorted(self.poolmember.items(),key = lambda x :x[1]['memory_free'],reverse = True)[:1][0][1]
+
+    # Generate migration plan
+    def generate_migration_plan(self):
+        if self.is_host_enabled() is not False:
+            print "Error: Host should be disabled first."
+            return False
+
+        migration_cmds = ""
+        if self.vmlist == False:
+            self.vmlist = self.get_vms_with_memory_from_hypervisor()
+
+        vmlist_iter = self.vmlist.split('\n')
+
+        for vm in vmlist_iter:
+            info = vm.split(',')
+            try:
+                vm = info[0]
+                mem = int(info[1].strip())
+            except:
+                continue
+
+            while True:
+                to_hv = self.get_hypervisor_with_most_free_memory()
+
+                # If the hv with the most memory cannot host this vm, we're in trouble
+                if to_hv['memory_free'] > mem:
+                    # update free_mem
+                    self.poolmember[to_hv['name']]['memory_free'] -= int(mem)
+                    # Prepare migration command
+                    migration_cmds += "xe vm-migrate vm=" + vm + " host=" + to_hv['name'] + ";\n"
+                    break
+                else:
+                    # Unable to empty this hv
+                    print "Error: not enough memory (need: " + str(mem)  + ") on host with the most free memory!"
+                    return False
+        return migration_cmds
+
+    # Execute migration plan
+    def execute_migration_plan(self):
+         try:
+            migration_cmds = self.generate_migration_plan()
+            if migration_cmds == False:
+                return False
+            return self.run_local_command("nohup echo \"" + migration_cmds + "\" | \
+                                           xargs -n 1 -P " + str(self.threads) + " -I {} bash -c \{\} 2>&1 >/dev/null &")
+         except:
+             return False
+
+    # Is host enabled?
+    def is_host_enabled(self):
+        print "Note: Checking if host is enabled or disabled.."
+        try:
+            if self.run_local_command("xe host-list params=enabled name-label=$HOSTNAME --minimal").strip() == "true":
+                return True
+            else:
+                return False
+        except:
+            return "Error"
+
+    # Put a host to service in XenServer
+    def host_enable(self):
+        print "Note: Enabling host "
+        try:
+            return self.run_local_command("xe host-enable host=$HOSTNAME")
+        except:
+            return False
+
+    # Put a host to maintenance in XenServer
+    def host_disable(self):
+        print "Note: Disabling host "
+        try:
+            return self.run_local_command("xe host-disable host=$HOSTNAME")
+        except:
+            print "Warning: host_disable returned false"
+            return False
+
+    # Check the current state of HA
+    def pool_ha_check(self):
+        try:
+           if self.run_local_command("xe pool-list params=ha-enabled | \
+                                      awk {'print $5'} | tr -d '\n'") == "true":
+               return True
+           else:
+               return False
+        except:
+            return "Error"
+
+# Main program
+if __name__ == "__main__":
+    arg = handleArguments()
+    arg.handleArguments(sys.argv[1:])
+
+    # Init our class
+    x = xenserver_parallel_evacuation(arg)
+
+    if arg.DRYRUN == 1:
+        print "Note: Running in DRY-run mode, not executing. Use --exec to execute."
+        print "Note: Calculating migration plan.."
+        print "Note: This is the migration plan:"
+        print x.generate_migration_plan()
+        sys.exit(0)
+
+    print "Note: Executing migration plan using " + str(x.threads) + " threads.."
+    print x.execute_migration_plan()
+

--- a/xenserver_parallel_evacuate.py
+++ b/xenserver_parallel_evacuate.py
@@ -127,10 +127,17 @@ class xenserver_parallel_evacuation(object):
 
     # Generate migration plan
     def generate_migration_plan(self):
+        # Make sure host is disabled
         if self.is_host_enabled() is not False:
             print "Error: Host should be disabled first."
             return False
 
+        # Make sure pool HA is turned off
+        if self.pool_ha_check() is not False:
+            print "Error: Pool HA should be disabled first."
+            return False
+
+        # Generate migration plan
         migration_cmds = ""
         if self.vmlist == False:
             self.vmlist = self.get_vms_with_memory_from_hypervisor()

--- a/xenserver_parallel_evacuate.py
+++ b/xenserver_parallel_evacuate.py
@@ -24,11 +24,8 @@
 
 # We depend on these modules
 import sys
-import socket
-import time
 import os
 import getopt
-import subprocess
 
 
 # Argument handling Class
@@ -185,23 +182,6 @@ class xenserver_parallel_evacuation(object):
                 return False
         except:
             return "Error"
-
-    # Put a host to service in XenServer
-    def host_enable(self):
-        print "Note: Enabling host "
-        try:
-            return self.run_local_command("xe host-enable host=$HOSTNAME")
-        except:
-            return False
-
-    # Put a host to maintenance in XenServer
-    def host_disable(self):
-        print "Note: Disabling host "
-        try:
-            return self.run_local_command("xe host-disable host=$HOSTNAME")
-        except:
-            print "Warning: host_disable returned false"
-            return False
 
     # Check the current state of HA
     def pool_ha_check(self):

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -139,6 +139,7 @@ output['running'] = False
 output['stdout'] = False
 output['stdin'] = False
 output['output'] = False
+output['warnings'] = False
 
 # Check cloudstack IDs
 if DEBUG == 1:

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
 c = cloudstackops.CloudStackOps(DEBUG, DRYRUN)
 
 # Init XenServer class
-x = xenserver.xenserver('root', 2)
+x = xenserver.xenserver('root', threads)
 c.xenserver = x
 
 # make credentials file known to our class

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -43,12 +43,12 @@ def handleArguments(argv):
     DEBUG = 0
     global DRYRUN
     DRYRUN = 1
+    global PREPARE
+    PREPARE = 0
     global clustername
     clustername = ''
     global configProfileName
     configProfileName = ''
-    global force
-    force = 0
     global ignoreHostList
     ignoreHostList = ""
     global ignoreHosts
@@ -63,12 +63,13 @@ def handleArguments(argv):
         '\n  --ignore-hosts <list>\t\t\t\tSkip work on the specified hosts (for example if you need to resume): Example: --ignore-hosts="host1, host2" ' + \
         '\n  --threads <nr>\t\t\t\tUse this number or concurrent migration threads" ' + \
         '\n  --debug\t\t\t\t\tEnable debug mode' + \
-        '\n  --exec\t\t\t\t\tExecute for real'
+        '\n  --exec\t\t\t\t\tExecute for real' + \
+        '\n  --prepare\t\t\t\t\tExecute some prepare commands'
 
     try:
         opts, args = getopt.getopt(
-            argv, "hc:n:t:", [
-                "credentials-file=", "clustername=", "ignore-hosts=", "threads=", "debug", "exec", "force"])
+            argv, "hc:n:t:p", [
+                "credentials-file=", "clustername=", "ignore-hosts=", "threads=", "debug", "exec", "prepare"])
     except getopt.GetoptError as e:
         print "Error: " + str(e)
         print help
@@ -90,8 +91,8 @@ def handleArguments(argv):
             DEBUG = 1
         elif opt in ("--exec"):
             DRYRUN = 0
-        elif opt in ("--force"):
-            force = 1
+        elif opt in ("--prepare"):
+            PREPARE = 1
 
     # Default to cloudmonkey default config file
     if len(configProfileName) == 0:
@@ -179,13 +180,13 @@ print "Note: The poolmaster of cluster " + clustername + " is " + poolmaster_nam
 # Put the scripts we need
 for h in cluster_hosts:
     x.put_scripts(h)
-    if DRYRUN == 0:
+    if DRYRUN == 0 or PREPARE == 1:
         x.fake_pv_tools(h)
     if h.name == poolmaster_name:
         poolmaster = h
 
 # Eject CDs
-if DRYRUN == 0:
+if DRYRUN == 0 or PREPARE == 1:
     eject_result = x.eject_cds(poolmaster)
     if eject_result == False:
         print "Warning: Ejecting CDs failed. Continuing anyway."

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -53,19 +53,22 @@ def handleArguments(argv):
     ignoreHostList = ""
     global ignoreHosts
     ignoreHosts = ''
+    global threads
+    threads = 5
 
     # Usage message
     help = "Usage: ./" + os.path.basename(__file__) + ' [options]' + \
         '\n  --config-profile -c <profilename>\t\tSpecify the CloudMonkey profile name to get the credentials from (or specify in ./config file)' + \
         '\n  --clustername -n <clustername> \t\tName of the cluster to work with' + \
         '\n  --ignore-hosts <list>\t\t\t\tSkip work on the specified hosts (for example if you need to resume): Example: --ignore-hosts="host1, host2" ' + \
+        '\n  --threads <nr>\t\t\t\tUse this number or concurrent migration threads" ' + \
         '\n  --debug\t\t\t\t\tEnable debug mode' + \
         '\n  --exec\t\t\t\t\tExecute for real'
 
     try:
         opts, args = getopt.getopt(
-            argv, "hc:n:", [
-                "credentials-file=", "clustername=", "ignore-hosts=", "debug", "exec", "force"])
+            argv, "hc:n:t:", [
+                "credentials-file=", "clustername=", "ignore-hosts=", "threads=", "debug", "exec", "force"])
     except getopt.GetoptError as e:
         print "Error: " + str(e)
         print help
@@ -79,6 +82,8 @@ def handleArguments(argv):
             configProfileName = arg
         elif opt in ("-n", "--clustername"):
             clustername = arg
+        elif opt in ("-t", "--threads"):
+            threads = arg
         elif opt in ("--ignore-hosts"):
             ignoreHostList = arg
         elif opt in ("--debug"):
@@ -111,7 +116,7 @@ if __name__ == '__main__':
 c = cloudstackops.CloudStackOps(DEBUG, DRYRUN)
 
 # Init XenServer class
-x = xenserver.xenserver()
+x = xenserver.xenserver('root', 2)
 c.xenserver = x
 
 # make credentials file known to our class

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -160,6 +160,12 @@ for h in cluster_hosts:
     if h.name == poolmaster_name:
         poolmaster = h
 
+# Eject CDs
+if DRYRUN == 0:
+    eject_result = x.eject_cds(poolmaster)
+    if eject_result == False:
+        print "Warning: Ejecting CDs failed. Continuing anyway."
+
 # Print overview
 checkBonds = True
 c.printHypervisors(clusterID, poolmaster.name, checkBonds)

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -113,7 +113,10 @@ if DEBUG == 1:
 # Set user/passwd for fabric ssh
 env.user = 'root'
 env.password = 'password'
+env.forward_agent = True
+env.disable_known_hosts = True
 env.parallel = False
+env.pool_size = 1
 
 # Supress Fabric output by default, we will enable when needed
 output['debug'] = False

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -1,0 +1,282 @@
+#!/usr/bin/python
+
+#      Copyright 2015, Schuberg Philis BV
+#
+#      Licensed to the Apache Software Foundation (ASF) under one
+#      or more contributor license agreements.  See the NOTICE file
+#      distributed with this work for additional information
+#      regarding copyright ownership.  The ASF licenses this file
+#      to you under the Apache License, Version 2.0 (the
+#      "License"); you may not use this file except in compliance
+#      with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#      Unless required by applicable law or agreed to in writing,
+#      software distributed under the License is distributed on an
+#      "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#      KIND, either express or implied.  See the License for the
+#      specific language governing permissions and limitations
+#      under the License.
+
+# Patch XenServers that are registered in CloudStack
+# Remi Bergsma, rbergsma@schubergphilis.com
+
+# We depend on these modules
+import sys
+import socket
+import time
+import os
+import getopt
+from cloudstackops import cloudstackops
+from cloudstackops import xenserver
+# Fabric
+from fabric.api import *
+from fabric import api as fab
+from fabric import *
+
+
+# Handle arguments passed
+def handleArguments(argv):
+    global DEBUG
+    DEBUG = 0
+    global DRYRUN
+    DRYRUN = 1
+    global clustername
+    clustername = ''
+    global configProfileName
+    configProfileName = ''
+    global force
+    force = 0
+
+    # Usage message
+    help = "Usage: ./" + os.path.basename(__file__) + ' [options]' + \
+        '\n  --config-profile -c <profilename>\t\tSpecify the CloudMonkey profile name to get the credentials from (or specify in ./config file)' + \
+        '\n  --clustername -n <clustername> \t\tName of the cluster to work with' + \
+        '\n  --debug\t\t\t\t\tEnable debug mode' + \
+        '\n  --exec\t\t\t\t\tExecute for real'
+
+    try:
+        opts, args = getopt.getopt(
+            argv, "hc:n:", [
+                "credentials-file=", "clustername=", "debug", "exec", "force"])
+    except getopt.GetoptError as e:
+        print "Error: " + str(e)
+        print help
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '-h':
+
+            print help
+            sys.exit()
+        elif opt in ("-c", "--config-profile"):
+            configProfileName = arg
+        elif opt in ("-n", "--clustername"):
+            clustername = arg
+        elif opt in ("--debug"):
+            DEBUG = 1
+        elif opt in ("--exec"):
+            DRYRUN = 0
+        elif opt in ("--force"):
+            force = 1
+
+    # Default to cloudmonkey default config file
+    if len(configProfileName) == 0:
+        configProfileName = "config"
+
+    if len(clustername) == 0:
+        print help
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    handleArguments(sys.argv[1:])
+
+# Init CloudStack class
+c = cloudstackops.CloudStackOps(DEBUG, DRYRUN)
+
+# Init XenServer class
+x = xenserver.xenserver()
+c.xenserver = x
+
+# make credentials file known to our class
+c.configProfileName = configProfileName
+
+# Init the CloudStack API
+c.initCloudStackAPI()
+
+if DEBUG == 1:
+    print "API address: " + c.apiurl
+    print "ApiKey: " + c.apikey
+    print "SecretKey: " + c.secretkey
+
+# Set user/passwd for fabric ssh
+env.user = 'root'
+env.password = 'password'
+env.parallel = False
+
+# Supress Fabric output by default, we will enable when needed
+output['debug'] = False
+output['running'] = False
+output['stdout'] = False
+output['stdin'] = False
+output['output'] = False
+
+# Check cloudstack IDs
+if DEBUG == 1:
+    print "Note: Checking CloudStack IDs of provided input.."
+clusterID = c.checkCloudStackName(
+    {'csname': clustername, 'csApiCall': 'listClusters'})
+if clusterID == 1:
+    print "Error: Could not find cluster '" + clustername + "'."
+    sys.exit(1)
+
+# Get cluster hosts
+cluster_hosts = c.getAllHostsFromCluster(clusterID)
+first_host = cluster_hosts[0]
+
+# Print cluster info
+print "Note: Some info about cluster '" + clustername + "':"
+c.printCluster(clusterID)
+
+# Get poolmaster
+poolmaster_name = x.get_poolmaster(first_host)
+if not poolmaster_name:
+    print "Error: unable to figure out the poolmaster while talking to " + first_hostname
+    sys.exit(1)
+print "Note: The poolmaster of cluster " + clustername + " is " + poolmaster_name
+
+# Put the scripts we need
+for h in cluster_hosts:
+    x.put_scripts(h)
+    if DRYRUN == 0:
+        x.fake_pv_tools(h)
+    if h.name == poolmaster_name:
+        poolmaster = h
+
+# Print overview
+checkBonds = True
+c.printHypervisors(clusterID, poolmaster.name, checkBonds)
+
+if DRYRUN == 1:
+    print
+    print "Warning: We are running in DRYRUN mode."
+    print
+    print "This script will: "
+    print "  - Set cluster " + clustername + " to unmanage in CloudStack"
+    print "  - Turn OFF XenServer poolHA for " + clustername
+    print "  - For any hypervisor it will do this (poolmaster " + poolmaster.name + " first):"
+    print "      - put it to Disabled aka Maintenance in XenServer"
+    print "      - live migrate all VMs off of it using XenServer evacuate command"
+    print "      - when empty, it will reboot the hypervisor"
+    print "      - will wait for it to come back online (checks SSH connection)"
+    print "      - set the hypervisor to Enabled in XenServer"
+    print "      - continues to the next hypervisor"
+    print "  - When the rebooting is done, it enables XenServer poolHA again for " + clustername
+    print "  - Finally, it sets the " + clustername + " to Managed again in CloudStack"
+    print "  - CloudStack will update its admin according to the new situation"
+    print "Then the reboot cyclus for " + clustername + " is done!"
+    print
+    print "To kick it off, run with the --exec flag."
+    sys.exit(1)
+
+# Start time
+print "Note: Starting @ " + time.strftime("%Y-%m-%d %H:%M")
+
+# Set to unmanage in CloudStack
+print "Note: Setting cluster " + clustername + " to Unmanaged in CloudStack"
+clusterUpdateReturn = c.updateCluster(
+    {'clusterid': clusterID, 'managedstate': 'Unmanaged'})
+
+if clusterUpdateReturn == 1 or clusterUpdateReturn is None:
+    print "Error: Unmanaging cluster " + clustername + " failed. Halting."
+    sys.exit(1)
+
+# Check HA of Cluster
+pool_ha = x.pool_ha_check(poolmaster)
+if pool_ha == "Error":
+    print "Error: Unable to get the current HA state of cluster " + clustername
+    sys.ext(1)
+print "Note: The state of HA on cluster " + clustername + " is " + str(pool_ha)
+
+# Disable HA
+if pool_ha:
+    pool_ha_result = x.pool_ha_disable(poolmaster)
+    if pool_ha_result == "Error":
+        print "Error: Unable to set the HA state to Disabled for cluster " + clustername
+        sys.exit(1)
+    pool_ha = x.pool_ha_check(poolmaster)
+    print "Note: The state of HA on cluster " + clustername + " is " + str(pool_ha)
+
+# Do the poolmaster first
+vm_count = x.host_get_vms(poolmaster)
+if vm_count:
+    print "Note: " + poolmaster.name + " (poolmaster) has " + vm_count + " VMs running."
+    reboot_result = x.host_reboot(poolmaster)
+    if reboot_result is False:
+        print "Error: Stopping sequence, as a reboot failed. Please investigate."
+        x.roll_back(poolmaster)
+        sys.exit(1)
+else:
+    print "Error: Unable to contact the poolmaster " + poolmaster.name
+    sys.exit(1)
+
+# Print overview
+checkBonds = True
+c.printHypervisors(clusterID, poolmaster.name, checkBonds)
+
+# Then the other hypervisors, one-by-one
+for h in cluster_hosts:
+    if h.name == poolmaster.name:
+        print "Note: Skipping poolmaster"
+        continue
+    vm_count = x.host_get_vms(h)
+    if vm_count:
+        print "Note: " + h.name + " has " + vm_count + " VMs running."
+        reboot_result = x.host_reboot(h)
+        if reboot_result is False:
+            print "Error: Stopping sequence, as a reboot failed. Please investigate."
+            x.roll_back(h)
+            sys.exit(1)
+    else:
+        print "Error: Unable to get vm_count from host " + h.name
+        x.roll_back(h)
+        sys.exit(1)
+    print "Note: We completed host " + h.name + " successfully."
+
+    # Print overview
+    checkBonds = True
+    c.printHypervisors(clusterID, poolmaster.name, checkBonds)
+
+# Enable HA
+pool_ha_result = x.pool_ha_enable(poolmaster)
+if pool_ha_result is False:
+    print "Warning: Unable to set the HA state to Enable for cluster " + clustername
+
+# Check HA
+pool_ha = x.pool_ha_check(poolmaster)
+if pool_ha == "Error":
+    print "Error: Unable to get the current HA state of cluster " + clustername
+    sys.ext(1)
+print "Note: The state of HA on cluster " + clustername + " is " + str(pool_ha)
+
+# Set to manage in CloudStack
+clusterUpdateReturn = c.updateCluster(
+    {'clusterid': clusterID, 'managedstate': 'Managed'})
+
+if clusterUpdateReturn == 1 or clusterUpdateReturn is None:
+    print "Error: Managing cluster " + clustername + " failed. Please check manually."
+    sys.exit(1)
+
+# Print cluster info
+print "Note: Some info about cluster '" + clustername + "':"
+c.printCluster(clusterID)
+
+# Let the SSH connections cleanup before the main tread stops
+time.sleep(5)
+
+# Done
+print "Note: We're done with cluster " + clustername
+
+# End time
+print "Note: Finished @ " + time.strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
This script can reboot a XenServer cluster while keeping all VMs running. It will live-migrate them around and need a N+1 situation, so it can reboot one hypervisor at a time. It will take care of everything that needs to be done in CloudStack and XenServer itself and will return the cluster to survive after it is done.

Unless the default XenServer evacuate method, this script migrates with 5 parallel threads and is therefor 2 to 3 times faster.
