### PR TITLE
Support XenServer 6.5

### DIFF
--- a/cloudstackops/cloudstackopsssh.py
+++ b/cloudstackops/cloudstackopsssh.py
@@ -86,7 +86,11 @@ class CloudStackOpsSSH(CloudStackOpsBase):
 
     # Get xapi vm count
     def getXapiVmCount(self, hostname):
-        remoteCmd = "xl list-vm | grep -v UUID | wc -l"
+        remoteCmd = "xe vm-list resident-on=$(xe host-list params=uuid \
+                     name-label=$HOSTNAME --minimal) \
+                     params=name-label,memory-static-max is-control-domain=false | \
+                     tr '\\n' ' ' | sed 's/name-label/\\n/g' | \
+                     awk {'print $4 \",\" $8'} | sed '/^,$/d'| wc -l"
         return self.runSSHCommand(hostname, remoteCmd)
 
     # Migrate vm via xapi

--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -207,7 +207,11 @@ class xenserver():
     def host_get_vms(self, host):
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
-                return fab.run("xl list-vm | grep -v UUID | wc -l")
+                return fab.run("xe vm-list resident-on=$(xe host-list params=uuid \
+                name-label=$HOSTNAME --minimal) \
+                params=name-label,memory-static-max is-control-domain=false | \
+                tr '\\n' ' ' | sed 's/name-label/\\n/g' | \
+                awk {'print $4 \",\" $8'} | sed '/^,$/d'| wc -l")
         except:
             return False
 


### PR DESCRIPTION
XenServer 6.5 uses 'xl vm-list' whereas the same on XenServer 6.2 used to be 'xl list-vm'.

This closes #13