### PR TITLE
Do not list HA workers without VMname

### DIFF
--- a/listHAWorkers.py
+++ b/listHAWorkers.py
@@ -153,8 +153,11 @@ for (vmname, vm_type, state, created, taken, step, hypervisor, mgtname,
         continue
     if len(vmnameFilter) > 0 and vmname.find(vmnameFilter) < 0:
         continue
+    if vmname == None:
+       continue
     counter = counter + 1
     displayname = (vmname[:28] + '..') if len(vmname) >= 31 else vmname
+    mgtname = mgtname.split(".")[0]
     t.add_row([
         displayname,
         vm_type,


### PR DESCRIPTION
This closes #22

Ignore lines with no vmname and make the app servers name only display the hostname, no domain (to save space).