### PR TITLE
Add --halt flag to halt hypervisor instead of reboot

### DIFF
--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -49,7 +49,7 @@ output['warnings'] = False
 # Class to handle XenServer patching
 class xenserver():
 
-    def __init__(self, ssh_user='root', threads = 5):
+    def __init__(self, ssh_user='root', threads=5):
         self.ssh_user = ssh_user
         self.threads = threads
 
@@ -166,7 +166,7 @@ class xenserver():
             return False
 
     # Reboot a host when all conditions are met
-    def host_reboot(self, host):
+    def host_reboot(self, host, halt_hypervisor=False):
         # Disbale host
         if self.host_disable(host) is False:
             print "Error: Disabling host " + host.name + " failed."
@@ -184,10 +184,14 @@ class xenserver():
         print "Note: Host " + host.name + " has no VMs running, continuing"
 
         # Finally reboot it
-        print "Note: Rebooting host " + host.name
         try:
             with settings(host_string=self.ssh_user + "@" + host.ipaddress):
-                fab.run("xe host-reboot host=" + host.name)
+                if halt_hypervisor:
+                    print "Note: Halting host " + host.name
+                    fab.run("xe host-shutdown host=" + host.name)
+                else:
+                    print "Note: Rebooting host " + host.name
+                    fab.run("xe host-reboot host=" + host.name)
         except:
             print "Error: Rebooting host " + host.name + " failed."
             return False


### PR DESCRIPTION
Add `--halt` flag to allow for hardware maintenance. Script will continue when hypervisor is back.

![image](https://cloud.githubusercontent.com/assets/1630096/15975088/15b58d62-2f4c-11e6-8f3b-a5b294bc187d.png)

After manual power on it will continue:
![screen shot 2016-06-10 at 20 45 07](https://cloud.githubusercontent.com/assets/1630096/15975126/443ed490-2f4c-11e6-9d6a-80ddcc6b77c5.png)

(this is a quick demo with a single host)