### PR TITLE
Unmanage state only when the poolmaster is being rebooted

### DIFF
--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -65,9 +65,9 @@ def handleArguments(argv):
         '\n  --clustername -n <clustername> \t\tName of the cluster to work with' + \
         '\n  --ignore-hosts <list>\t\t\t\tSkip work on the specified hosts (for example if you need to resume): ' \
         'Example: --ignore-hosts="host1, host2" ' + \
-        '\n  --threads <nr>\t\t\t\tUse this number or concurrent migration threads" ' + \
+        '\n  --threads <nr>\t\t\t\tUse this number or concurrent migration threads ' + \
         '\n  --halt\t\t\t\t\tInstead of the default reboot, halt the hypervisor (useful in case of hardware ' \
-        'upgrades)" ' + \
+        'upgrades) ' + \
         '\n  --debug\t\t\t\t\tEnable debug mode' + \
         '\n  --exec\t\t\t\t\tExecute for real' + \
         '\n  --prepare\t\t\t\t\tExecute some prepare commands'
@@ -268,6 +268,20 @@ else:
 checkBonds = True
 c.printHypervisors(clusterID, poolmaster.name, checkBonds)
 
+# Set to manage in CloudStack
+print "Note: Setting cluster " + clustername + " back to Managed in CloudStack"
+clusterUpdateReturn = c.updateCluster(
+    {'clusterid': clusterID, 'managedstate': 'Managed'})
+
+if clusterUpdateReturn == 1 or clusterUpdateReturn is None:
+    print "Error: Managing cluster " + clustername + " failed. Please check manually."
+    disconnect_all()
+    sys.exit(1)
+
+# Print cluster info
+print "Note: Some info about cluster '" + clustername + "':"
+c.printCluster(clusterID)
+
 # Then the other hypervisors, one-by-one
 for h in cluster_hosts:
     if h.name in ignoreHosts:
@@ -309,15 +323,6 @@ if pool_ha == "Error":
     disconnect_all()
     sys.ext(1)
 print "Note: The state of HA on cluster " + clustername + " is " + str(pool_ha)
-
-# Set to manage in CloudStack
-clusterUpdateReturn = c.updateCluster(
-    {'clusterid': clusterID, 'managedstate': 'Managed'})
-
-if clusterUpdateReturn == 1 or clusterUpdateReturn is None:
-    print "Error: Managing cluster " + clustername + " failed. Please check manually."
-    disconnect_all()
-    sys.exit(1)
 
 # Print cluster info
 print "Note: Some info about cluster '" + clustername + "':"


### PR DESCRIPTION
Putting a cluster to unmanage means no operations can be executed. As rebooting a cluster takes some time, it's best to minimise the time a cluster is put to unmanage.

This PR changes it from the whole maintenance period to just the time it takes to do the poolmaster. As the poolmaster is done first, unmanage state starts at beginning of maintenance window and when the slaves are done we're back in business.

There are a few things to know about this:
- the host that is being "emptied" is put in "disabled" mode in XenServer. In CloudStack this results in Alert state
- you may want to filter these Alerts as they are expected
- all VMs on the hypervisor that is being "emptied" (also routers) are unmanageable and will result in errors. This gets better automatically as they are migrated out-of-band and show up on the other hypervisors that report it to CloudStack
- in other words, there is still some impact but not as massively and as long as before. Now a retry after a few minutes will most likely succeed.

Test run:
```
1 rbergsma@mccdpod01-hv01:~/cloudstackOps$ ./xenserver_rolling_reboot.py -c local -n MCCT-XEN-1 --exec                                        
Welcome to CloudStackOps                                                                                                                      
Note: Trying to use API credentials from CloudMonkey profile 'local'                                                                          
Note: Connected to 'http://cs1.cloud.lan:8080/client/api'                                                                                     
Note: Some info about cluster 'MCCT-XEN-1':                                                                                                   
+--------------+------------------+---------------+--------------+-------------+----------+---------------+                                   
| Cluster name | Allocation state | Managed state | XenServer HA | Patch level | Pod name |   Zone name   |                                   
+--------------+------------------+---------------+--------------+-------------+----------+---------------+                                   
| MCCT-XEN-1   |     Enabled      |    Managed    |    False     |             | MCCT-POD | MCCT-SHARED-1 |                                   
+--------------+------------------+---------------+--------------+-------------+----------+---------------+                                   
Note: The poolmaster of cluster MCCT-XEN-1 is xen1                                                                                            
Note: We're faking the presence of PV tools of all vm's reporting no tools on hypervisor xen3                                                 
Note: We're faking the presence of PV tools of all vm's reporting no tools on hypervisor xen1                                                 
Note: We're faking the presence of PV tools of all vm's reporting no tools on hypervisor xen2                                                 
Note: We're ejecting all mounted CDs on this cluster.                                                                                         
+----------+------------+----------------+-------+-------+-------------+                                                                      
| Hostname | Poolmaster | Resource state | State | # VMs | Bond Status |                                                                      
+----------+------------+----------------+-------+-------+-------------+                                                                      
|   xen1   |  <------   |    Enabled     |   Up  |   6   |      OK     |                                                                      
|   xen2   |            |    Enabled     |   Up  |   5   |      OK     |                                                                      
|   xen3   |            |    Enabled     |   Up  |   10  |      OK     |                                                                      
+----------+------------+----------------+-------+-------+-------------+                                                                      
Note: Starting @ 2016-06-11 20:36                                                                                                             
Note: Setting cluster MCCT-XEN-1 to Unmanaged in CloudStack                                                                                   
Note: The state of HA on cluster MCCT-XEN-1 is False                                                                                          
Note: xen1 (poolmaster) has 6 VMs running.                                                                                                    
Note: Disabling host xen1                                                                                                                     
Note: Evacuating host xen1 @ 2016-06-11 20:36                                                                                                 
Progress: On host xen1 there are 0 VMs left to be migrated..                                                                                  
Note: Done evacuating host xen1 @ 2016-06-11 20:38                                                                                            
Note: Host xen1 has no VMs running, continuing                                                                                                
Note: Rebooting host xen1                                                                                                                     
Note: Host xen1 is now offline!                                                                                                               
Note: Host xen1 responds to SSH again!                                                                                                        
Note: Host xen1 is able to do XE stuff again!                                                                                                 
Note: Enabling host xen1                                                                                                                      
+----------+------------+----------------+--------------+-------+-------------+                                                               
| Hostname | Poolmaster | Resource state |    State     | # VMs | Bond Status |                                                               
+----------+------------+----------------+--------------+-------+-------------+                                                               
|   xen1   |  <------   |    Enabled     | Disconnected |   0   |      OK     |                                                               
|   xen2   |            |    Enabled     | Disconnected |   11  |      OK     |                                                               
|   xen3   |            |    Enabled     | Disconnected |   10  |      OK     |                                                               
+----------+------------+----------------+--------------+-------+-------------+                                                               
Note: Setting cluster MCCT-XEN-1 back to Managed in CloudStack                                                                                
Note: Some info about cluster 'MCCT-XEN-1':
+--------------+------------------+---------------+--------------+-------------+----------+---------------+
| Cluster name | Allocation state | Managed state | XenServer HA | Patch level | Pod name |   Zone name   |
+--------------+------------------+---------------+--------------+-------------+----------+---------------+
| MCCT-XEN-1   |     Enabled      |    Managed    |    False     |             | MCCT-POD | MCCT-SHARED-1 |
+--------------+------------------+---------------+--------------+-------------+----------+---------------+
Note: xen3 has 10 VMs running.
Note: Disabling host xen3
Note: Evacuating host xen3 @ 2016-06-11 20:39
Progress: On host xen3 there are 0 VMs left to be migrated...
Note: Done evacuating host xen3 @ 2016-06-11 21:02
Note: Host xen3 has no VMs running, continuing
Note: Rebooting host xen3
Note: Host xen3 is now offline!                           
Note: Host xen3 responds to SSH again!                           
Note: Host xen3 is able to do XE stuff again!                                  
Note: Enabling host xen3
Note: We completed host xen3 successfully.
+----------+------------+----------------+--------------+-------+-------------+
| Hostname | Poolmaster | Resource state |    State     | # VMs | Bond Status |
+----------+------------+----------------+--------------+-------+-------------+
|   xen1   |  <------   |    Enabled     |      Up      |   10  |      OK     |
|   xen2   |            |    Enabled     |      Up      |   11  |      OK     |
|   xen3   |            |    Enabled     | Disconnected |   0   |      OK     |
+----------+------------+----------------+--------------+-------+-------------+
Note: Skipping poolmaster
Note: xen2 has 11 VMs running.
Note: Disabling host xen2
Note: Evacuating host xen2 @ 2016-06-11 21:04
Progress: On host xen2 there are 0 VMs left to be migrated...
Note: Done evacuating host xen2 @ 2016-06-11 21:06
Note: Host xen2 has no VMs running, continuing
Note: Rebooting host xen2
Note: Host xen2 is now offline!                           
Note: Host xen2 responds to SSH again!                           
Note: Host xen2 is able to do XE stuff again!                                  
Note: Enabling host xen2
Note: We completed host xen2 successfully.
+----------+------------+----------------+-------+-------+-------------+
| Hostname | Poolmaster | Resource state | State | # VMs | Bond Status |
+----------+------------+----------------+-------+-------+-------------+
|   xen1   |  <------   |    Enabled     |   Up  |   11  |      OK     |
|   xen2   |            |    Enabled     | Alert |   0   |      OK     |
|   xen3   |            |    Enabled     |   Up  |   12  |      OK     |
+----------+------------+----------------+-------+-------+-------------+
Note: Enabling HA
Note: The state of HA on cluster MCCT-XEN-1 is True
Note: Some info about cluster 'MCCT-XEN-1':
+--------------+------------------+---------------+--------------+-------------+----------+---------------+
| Cluster name | Allocation state | Managed state | XenServer HA | Patch level | Pod name |   Zone name   |
+--------------+------------------+---------------+--------------+-------------+----------+---------------+
| MCCT-XEN-1   |     Enabled      |    Managed    |     True     |             | MCCT-POD | MCCT-SHARED-1 |
+--------------+------------------+---------------+--------------+-------------+----------+---------------+
Disconnecting from 192.168.22.13... done.
Disconnecting from 192.168.22.11... done.
Disconnecting from 192.168.22.12... done.
Note: We're done with cluster MCCT-XEN-1
Note: Finished @ 2016-06-11 21:10
```

As you can see I was able to spin some more VMs while the cluster was being rebooted :-)
