### PR TITLE
Added a script to create the missing VLANs for a XEN host

### DIFF
--- a/cloudstackops/xenserver.py
+++ b/cloudstackops/xenserver.py
@@ -298,6 +298,8 @@ class xenserver():
                     '/tmp/xenserver_check_bonds.py', mode=0755)
                 put('xenserver_fake_pvtools.sh',
                     '/tmp/xenserver_fake_pvtools.sh', mode=0755)
+                put('xenserver_create_vlans.sh',
+                    '/tmp/xenserver_create_vlans.sh', mode=0755)
                 put('xenserver_parallel_evacuate.py',
                     '/tmp/xenserver_parallel_evacuate.py', mode=0755)
                 if len(self.pre_empty_script) > 0:
@@ -329,6 +331,15 @@ class xenserver():
                 return fab.run("xe vm-list PV-drivers-up-to-date='<not in database>' is-control-domain=false\
                     resident-on=$(xe host-list name-label=$HOSTNAME --minimal) params=uuid --minimal\
                     |tr ', ' '\n'| grep \"-\" | awk {'print \"/tmp/xenserver_fake_pvtools.sh \" $1'} | sh")
+        except:
+            return False
+
+    # Create VLANs
+    def create_vlans(self, host):
+        print "Note: We're creating the missing VLAN's on hypervisor " + host.name
+        try:
+            with settings(host_string=self.ssh_user + "@" + host.ipaddress):
+                return fab.run("/tmp/xenserver_create_vlans.sh")
         except:
             return False
 

--- a/xenserver_create_vlans.sh
+++ b/xenserver_create_vlans.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#      Copyright 2015, Schuberg Philis BV
+#
+#      Licensed to the Apache Software Foundation (ASF) under one
+#      or more contributor license agreements.  See the NOTICE file
+#      distributed with this work for additional information
+#      regarding copyright ownership.  The ASF licenses this file
+#      to you under the Apache License, Version 2.0 (the
+#      "License"); you may not use this file except in compliance
+#      with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#      Unless required by applicable law or agreed to in writing,
+#      software distributed under the License is distributed on an
+#      "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#      KIND, either express or implied.  See the License for the
+#      specific language governing permissions and limitations
+#      under the License.
+
+# Script to create the missing VLANs on a XEN host
+# Ferenc Born - fborn@schubergphilis.com
+
+networks=$(xe network-list params=name-label | grep "\ VLAN" | awk -F': ' '{ print $2}')
+
+for network in $networks
+do
+	if [[ -z $(xe pif-list network-name-label=$network host-name-label=${HOSTNAME} --minimal) ]]; then
+		vlan=${network##*-}
+		networkuuid=$(xe network-list name-label=$network --minimal)
+		pifuuid=$(xe pif-list device=bond0 VLAN=-1 host-name-label=${HOSTNAME} --minimal)
+		echo "Note: Creating VLAN $vlan on hypervisor `hostname`"
+		xe vlan-create network-uuid=$networkuuid pif-uuid=$pifuuid vlan=$vlan
+		result=$?
+		if [[ $result != 0 ]]; then
+			echo "Error: Creating VLAN $vlan on hypervisor `hostname` failed with exit code $result"
+			exit 1
+		fi
+	fi
+done

--- a/xenserver_rolling_reboot.py
+++ b/xenserver_rolling_reboot.py
@@ -198,6 +198,7 @@ for h in cluster_hosts:
     x.put_scripts(h)
     if DRYRUN == 0 or PREPARE == 1:
         x.fake_pv_tools(h)
+        x.create_vlans(h)
     if h.name == poolmaster_name:
         poolmaster = h
 


### PR DESCRIPTION
A script to create the missing VLANs for a XEN host with VLAN based networking so every hypervisor has every VLAN plugged so all VMs can be migrated. This script will also work on a hypervisor with SDN, because not network-names are present with VLAN.