### PR TITLE
Add timeouts to the stop/start vm commands to prevent hangs

### DIFF
--- a/cloudstackops/cloudstackops.py
+++ b/cloudstackops/cloudstackops.py
@@ -699,24 +699,34 @@ class CloudStackOps(CloudStackOpsBase):
         s.quit()
 
     # Stop virtualvirtualmachine
-    def stopVirtualMachine(self, vmid):
-        apicall = stopVirtualMachine.stopVirtualMachineCmd()
-        apicall.id = str(vmid)
-        apicall.forced = "false"
+    def stopVirtualMachine(self, vmid, timeout=900):
+        try:
+            with Timeout(timeout):
+                apicall = stopVirtualMachine.stopVirtualMachineCmd()
+                apicall.id = str(vmid)
+                apicall.forced = "false"
 
-        # Call CloudStack API
-        return self._callAPI(apicall)
+                # Call CloudStack API
+                return self._callAPI(apicall)
+        except Timeout.Timeout:
+            print "Timeout!"
+            return 1
 
     # Start virtualvirtualmachine
-    def startVirtualMachine(self, vmid, hostid=""):
-        apicall = startVirtualMachine.startVirtualMachineCmd()
-        apicall.id = str(vmid)
-        apicall.forced = "false"
-        if len(hostid) > 0:
-            apicall.hostid = hostid
+    def startVirtualMachine(self, vmid, hostid="", timeout=900):
+        try:
+            with Timeout(timeout):
+                apicall = startVirtualMachine.startVirtualMachineCmd()
+                apicall.id = str(vmid)
+                apicall.forced = "false"
+                if len(hostid) > 0:
+                    apicall.hostid = hostid
 
-        # Call CloudStack API
-        return self._callAPI(apicall)
+                # Call CloudStack API
+                return self._callAPI(apicall)
+        except Timeout.Timeout:
+            print "Timeout!"
+            return 1
 
     # migrateVirtualMachine
     def migrateVirtualMachine(self, vmid, hostid):

--- a/cloudstackops/cloudstackopsbase.py
+++ b/cloudstackops/cloudstackopsbase.py
@@ -46,6 +46,25 @@ except:
     sys.exit(1)
 
 
+class Timeout:
+    """Timeout class using ALARM signal."""
+    class Timeout(Exception):
+        pass
+
+    def __init__(self, sec):
+        self.sec = sec
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.raise_timeout)
+        signal.alarm(self.sec)
+
+    def __exit__(self, *args):
+        signal.alarm(0)    # disable alarm
+
+    def raise_timeout(self, *args):
+        raise Timeout.Timeout()
+
+
 class CloudStackOpsBase(object):
 
     # Init function


### PR DESCRIPTION
After default of 900s it will return an error and break. The actual API command will keep running on the mgt server so that is not being cancelled (impossible).