### PR TITLE
Skip migrating disks on a pool of scope ZONE

### DIFF
--- a/migrateVirtualMachine.py
+++ b/migrateVirtualMachine.py
@@ -202,6 +202,11 @@ for vol in voldata:
         print "Warning: No need to migrate volume " + vol.name + " -- already on the desired storage pool. Skipping."
         continue
 
+    currentStorageData = c.getStoragePoolData(currentStorageID)[0]
+    if currentStorageData.scope == "ZONE":
+        print "Note: No need to migrate volume " + vol.name + " -- scope of this volume is ZONE. Skipping."
+        continue
+
     # Save ids for later -- we first need to find out if it's worth stopping
     # the vm
     volIDs.append(vol.id)


### PR DESCRIPTION
Example:
```
> ./migrateVirtualMachine.py -c cloud -t cluster -n vmname
Welcome to CloudStackOps
Warning: dry-run mode is enabled, not running any commands!
Note: Trying to use API credentials from CloudMonkey profile 'cloud'
Note: Found vm vmname with state Stopped
Note: No need to migrate volume LOG-1 -- scope of this volume is ZONE. Skipping.
Note: No need to migrate volume DATA-1 -- scope of this volume is ZONE. Skipping.
Note: No snapshots found for this volume.
Note: No snapshot schedules found for this volume.
Note: Would have migrated volume bd5a8903-1113-4d71-96e5-98c106113226 to storage aa3f7189-ff0a-3a69-a2a9-067cf2d4f486
Note: We're done!
```