### PR TITLE
Resolve issues with dedicated host handling

### DIFF
--- a/cloudstackops/cloudstackops.py
+++ b/cloudstackops/cloudstackops.py
@@ -1769,7 +1769,7 @@ class CloudStackOps(CloudStackOpsBase):
         migrationHost = False
 
         if clusterHosts != 1 and clusterHosts is not None:
-            [currentHost] = [h for h in self.getAllHostsFromCluster(clusterID) if h.name == currentHostname] or [""]
+            [currentHost] = [h for h in self.getAllHostsFromCluster(clusterID) if h.name == currentHostname] or [None]
 
             for h in clusterHosts:
                 # Skip the current hostname
@@ -1779,11 +1779,11 @@ class CloudStackOps(CloudStackOpsBase):
                 if h.suitableformigration == False:
                     continue
                 # Handle dedicated hosts
-                # if 'dedicated' in currentHost:
-                #    if currentHost.dedicated != h.dedicated:
-                #        continue
-                #    if currentHost.dedicated == True and currentHost.domainid != h.domainid:
-                #        continue
+                if currentHost:
+                    if currentHost.dedicated != h.dedicated:
+                        continue
+                    if currentHost.dedicated == True and currentHost.domainid != h.domainid:
+                        continue
                 # And are not in Maintenance, Error or Disabled
                 if h.resourcestate == "Disabled" or h.resourcestate == "Maintenance" or h.resourcestate == "Error":
                     continue


### PR DESCRIPTION
Dedicated hosts support had issues with migrations across clusters.
The patch to fix this introduced other issues. This re-enables dedicated hosts
support with a working fix for cross-cluster migration. 