### PR TITLE
Add maintenance policy to rolling reboot

### DIFF
--- a/kvm_rolling_reboot.py
+++ b/kvm_rolling_reboot.py
@@ -380,6 +380,11 @@ for host in cluster_hosts:
     message = "Host %s is connected to Cosmic, Enabled and in Up state" % host.name
     c.print_message(message=message, message_type="Note", to_slack=True)
 
+    # Start all VM's with migration policy ShutdownAndStart
+    message = "Starting all VM's on Host %s with ShutdownAndStart policy" % host.name
+    c.print_message(message=message, message_type="Note", to_slack=True)
+    c.startVmsWithShutPolicy()
+
     message = "Gathering some info about hypervisors in cluster '%s'" % clustername
     c.print_message(message=message, message_type="Note", to_slack=False)
     c.printHypervisors(clusterID, False, checkBonds, "KVM")


### PR DESCRIPTION
This PR takes maintenance policy of a VM in account. If the maintenance policy is `ShutdownAndStart` it will gracefully shutdown the VM and after the reboot will start the VM.